### PR TITLE
Use local storage state fix

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -10,18 +10,27 @@ import * as React from 'react'
 function useLocalStorageState(
   key,
   defaultValue = '',
+  // the = {} fixes the error we would get from destructuring when no argument was passed
+  // Check https://jacobparis.com/blog/destructure-arguments for a detailed explanation
   {serialize = JSON.stringify, deserialize = JSON.parse} = {},
 ) {
   const [state, setState] = React.useState(() => {
     const valueInLocalStorage = window.localStorage.getItem(key)
     if (valueInLocalStorage) {
-      return deserialize(valueInLocalStorage)
+      // the try/catch is here in case the localStorage value was set before
+      // we had the serialization in place (like we do in previous extra credits)
+      try {
+        return deserialize(valueInLocalStorage)
+      } catch (error) {
+        window.localStorage.removeItem(key)
+      }
     }
     return typeof defaultValue === 'function' ? defaultValue() : defaultValue
   })
 
   const prevKeyRef = React.useRef(key)
 
+  // Check the example at src/examples/local-state-key-change.js to visualize a key change
   React.useEffect(() => {
     const prevKey = prevKeyRef.current
     if (prevKey !== key) {


### PR DESCRIPTION
Resolves issue #217 by replacing the useLocalStorageState method in utils.js with the one from 02.extra-4.js that handles the error resulting from a non-JSON format being used for the state data