### PR TITLE
Update hooks official documentation link

### DIFF
--- a/exercises/01.managing-ui-state/README.mdx
+++ b/exercises/01.managing-ui-state/README.mdx
@@ -77,4 +77,4 @@ post/talk by [Shawn Wang](https://twitter.com/swyx):
 [Getting Closure on Hooks](https://www.swyx.io/getting-closure-on-hooks/)
 
 📜 And here's a reference to
-[the hooks official documentation](https://reactjs.org/hooks).
+[the hooks official documentation](https://react.dev/reference/react/hooks).


### PR DESCRIPTION
https://reactjs.org/hooks just redirects to https://react.dev/reference/react

Instead, could deeplink to: https://react.dev/reference/react/hooks