### PR TITLE
Handle scanner POSTs to catch-all routes

### DIFF
--- a/epicshop/package.json
+++ b/epicshop/package.json
@@ -1,6 +1,8 @@
 {
   "type": "module",
   "scripts": {
+    "postinstall": "node ./patch-workshop-app.js",
+    "test:patch": "node --test ./patch-workshop-app.test.js",
     "test:setup": "playwright install chromium --with-deps",
     "test": "playwright test"
   },

--- a/epicshop/patch-workshop-app.js
+++ b/epicshop/patch-workshop-app.js
@@ -1,0 +1,74 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const workshopAppServerBuildPath = path.join(
+	'node_modules',
+	'@epic-web',
+	'workshop-app',
+	'build',
+	'server',
+	'index.js',
+)
+
+const catchAllActionSource = `async function action$catchAll() {
+  throw new Response("Not Found", { status: 404 });
+}
+`
+
+const routeWithoutAction = `const route1 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
+  __proto__: null,
+  ErrorBoundary: ErrorBoundary$7,
+  default: $,
+  loader: loader$L
+}, Symbol.toStringTag, { value: "Module" }));`
+
+const routeWithAction = `const route1 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
+  __proto__: null,
+  ErrorBoundary: ErrorBoundary$7,
+  default: $,
+  action: action$catchAll,
+  loader: loader$L
+}, Symbol.toStringTag, { value: "Module" }));`
+
+const manifestWithoutAction = `"routes/$": { "id": "routes/$", "parentId": "root", "path": "*", "index": void 0, "caseSensitive": void 0, "hasAction": false,`
+const manifestWithAction = `"routes/$": { "id": "routes/$", "parentId": "root", "path": "*", "index": void 0, "caseSensitive": void 0, "hasAction": true,`
+
+export function patchServerBuild(contents) {
+	if (contents.includes('action: action$catchAll')) {
+		return contents
+	}
+
+	if (!contents.includes(routeWithoutAction)) {
+		throw new Error('Could not find the workshop app catch-all route module.')
+	}
+
+	if (!contents.includes(manifestWithoutAction)) {
+		throw new Error('Could not find the workshop app catch-all route manifest.')
+	}
+
+	return contents
+		.replace(routeWithoutAction, `${catchAllActionSource}${routeWithAction}`)
+		.replace(manifestWithoutAction, manifestWithAction)
+}
+
+export async function patchWorkshopApp({ cwd = __dirname } = {}) {
+	const serverBuildPath = path.join(cwd, workshopAppServerBuildPath)
+	const currentContents = await readFile(serverBuildPath, 'utf8')
+	const patchedContents = patchServerBuild(currentContents)
+
+	if (patchedContents === currentContents) {
+		return { serverBuildPath, patched: false }
+	}
+
+	await writeFile(serverBuildPath, patchedContents)
+	return { serverBuildPath, patched: true }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+	const { serverBuildPath, patched } = await patchWorkshopApp()
+	console.log(
+		`${patched ? 'Patched' : 'Already patched'} @epic-web/workshop-app catch-all route: ${serverBuildPath}`,
+	)
+}

--- a/epicshop/patch-workshop-app.test.js
+++ b/epicshop/patch-workshop-app.test.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { patchServerBuild } from './patch-workshop-app.js'
+
+const serverBuildFixture = `const route1 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
+  __proto__: null,
+  ErrorBoundary: ErrorBoundary$7,
+  default: $,
+  loader: loader$L
+}, Symbol.toStringTag, { value: "Module" }));
+const serverManifest = { "routes": { "routes/$": { "id": "routes/$", "parentId": "root", "path": "*", "index": void 0, "caseSensitive": void 0, "hasAction": false, "hasLoader": true } } };`
+
+test('patches the workshop app catch-all route with a 404 action', () => {
+	const patched = patchServerBuild(serverBuildFixture)
+
+	assert.match(
+		patched,
+		/async function action\$catchAll\(\) {\n  throw new Response\("Not Found", { status: 404 }\);\n}/,
+	)
+	assert.match(patched, /action: action\$catchAll,/)
+	assert.match(
+		patched,
+		/"routes\/\$": { "id": "routes\/\$", "parentId": "root", "path": "\*", "index": void 0, "caseSensitive": void 0, "hasAction": true,/,
+	)
+})
+
+test('patching the server build is idempotent', () => {
+	const patched = patchServerBuild(serverBuildFixture)
+
+	assert.equal(patchServerBuild(patched), patched)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add an install-time patch for `@epic-web/workshop-app` so the `routes/$` catch-all has a normal 404 action for unsupported method requests
- keep the fix scoped to the catch-all/splat route instead of suppressing all `getInternalRouterError` events
- add a focused node test covering the patch and idempotency

## Sentry
- epicshop EPICSHOP-F0 / 7447885629
- Example noisy request: `POST *splat /connectors/resource/index.php`

## Validation
- `npm --prefix epicshop run postinstall`
- `npm --prefix epicshop run test:patch`
- `npm run typecheck`
- `npm run lint`
- Smoke: `POST /connectors/resource/index.php` returned `HTTP/1.1 404 Not Found` with no server error log
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1961c71-749e-4314-b537-89ec22438ea5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1961c71-749e-4314-b537-89ec22438ea5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

