### PR TITLE
Ignore Picture-in-Picture Sentry noise

### DIFF
--- a/epicshop/package-lock.json
+++ b/epicshop/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "hasInstallScript": true,
       "dependencies": {
         "@epic-web/workshop-app": "^6.90.3",
         "@epic-web/workshop-utils": "^6.90.3",

--- a/epicshop/package.json
+++ b/epicshop/package.json
@@ -1,6 +1,7 @@
 {
   "type": "module",
   "scripts": {
+    "postinstall": "node ./patch-sentry-filters.js",
     "test:setup": "playwright install chromium --with-deps",
     "test": "playwright test"
   },

--- a/epicshop/patch-sentry-filters.js
+++ b/epicshop/patch-sentry-filters.js
@@ -1,0 +1,83 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const clientAssetsDir = path.join(
+	__dirname,
+	'node_modules',
+	'@epic-web',
+	'workshop-app',
+	'build',
+	'client',
+	'assets',
+)
+const existingPictureInPictureIgnore =
+	"Failed to execute 'requestPictureInPicture' on 'HTMLVideoElement'"
+const pictureInPictureRequestRaceMessage =
+	'The video element is processing a Picture-in-Picture request.'
+
+const sentryBeforeSendPattern = new RegExp(
+	`ignoreErrors:\\[${JSON.stringify(
+		existingPictureInPictureIgnore,
+	)}\\],beforeSend\\(([A-Za-z_$][\\w$]*)\\)\\{`,
+)
+
+const entryClientFilePattern = /^entry\.client-.*\.js$/
+
+const entries = await fs.readdir(clientAssetsDir)
+const entryClientFiles = entries.filter((entry) =>
+	entryClientFilePattern.test(entry),
+)
+
+if (entryClientFiles.length === 0) {
+	throw new Error(
+		`Could not find the workshop app entry.client bundle in ${clientAssetsDir}`,
+	)
+}
+
+let patched = false
+
+for (const entryClientFile of entryClientFiles) {
+	const entryClientPath = path.join(clientAssetsDir, entryClientFile)
+	const contents = await fs.readFile(entryClientPath, 'utf8')
+
+	if (contents.includes(pictureInPictureRequestRaceMessage)) {
+		console.log(
+			`Sentry Picture-in-Picture request-race filter already present in ${entryClientFile}`,
+		)
+		patched = true
+		continue
+	}
+
+	const updated = contents.replace(
+		sentryBeforeSendPattern,
+		(match, sentryEventName) =>
+			`${match}if(${sentryEventName}.exception?.values?.some((value)=>value.type==="NotAllowedError"&&value.value===${JSON.stringify(
+				pictureInPictureRequestRaceMessage,
+			)}))return null;`,
+	)
+
+	if (updated === contents) continue
+
+	await fs.writeFile(entryClientPath, updated)
+	console.log(
+		`Added Sentry Picture-in-Picture request-race filter to ${entryClientFile}`,
+	)
+	patched = true
+}
+
+if (!patched) {
+	throw new Error(
+		[
+			'Could not patch the workshop app Sentry beforeSend hook.',
+			'This filter intentionally drops only Safari DOMExceptions where',
+			`type is "NotAllowedError" and value is ${JSON.stringify(
+				pictureInPictureRequestRaceMessage,
+			)}.`,
+			'If @epic-web/workshop-app changed its client Sentry initialization,',
+			'update this patch instead of broadening the ignored NotAllowedError cases.',
+		].join(' '),
+	)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add an epicshop postinstall patch for the workshop app client Sentry beforeSend hook
- Drop only browser DOMExceptions where type is `NotAllowedError` and the value is exactly `The video element is processing a Picture-in-Picture request.`
- Document why the patch must remain narrow so unrelated `NotAllowedError` exceptions still report
- Update the epicshop lockfile metadata for the new install script

## Validation
- `npm --prefix epicshop run postinstall`
- `npm run typecheck`
- `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42d28d34-24b8-437a-96d3-513367540f57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42d28d34-24b8-437a-96d3-513367540f57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

